### PR TITLE
add listener support for points added by clicking

### DIFF
--- a/dist/lab-grapher.js
+++ b/dist/lab-grapher.js
@@ -272,6 +272,9 @@ module.exports = function Graph(idOrElement, options, message) {
       // An array containing two-element arrays consisting of X and Y values for samples/points
       points = [],
 
+      // Consumers of points that have been added by user clicks
+      pointListeners = [],
+
       // An array containing 1 or more points arrays to be plotted. Data is not indexed here
       // and sorted when "sortPoints" option is enabled.
       pointArray,
@@ -1538,6 +1541,9 @@ module.exports = function Graph(idOrElement, options, message) {
           newpoint[0] = xScale.invert(Math.max(0, Math.min(size.width,  p[0])));
           newpoint[1] = yScale.invert(Math.max(0, Math.min(size.height, p[1])));
           points.push(newpoint);
+          pointListeners.forEach(function(callback) {
+            callback.call(null,newpoint);
+          });
           points.sort(function(a, b) {
             if (a[0] < b[0]) { return -1; }
             if (a[0] > b[0]) { return  1; }
@@ -2583,6 +2589,17 @@ module.exports = function Graph(idOrElement, options, message) {
     */
     brushListener: function() {
       return brushListener;
+    },
+
+    /**
+      Allow consumption of points added to graph through clicking
+      */
+    addPointListener: function(callback) {
+      pointListeners.push(callback);
+    },
+
+    clearPointListeners: function() {
+      pointListeners.length = 0;
     },
 
     // specific update functions ???

--- a/examples/examples.js
+++ b/examples/examples.js
@@ -79,6 +79,10 @@ function selectDataHandler() {
       dataChange: true,
       addData: true
     });
+    graph.clearPointListeners();
+    graph.addPointListener(function(point){
+      console.log("clicked point: " + point);
+    });
     break;
 
   case "stair-steps":

--- a/lib/graph.js
+++ b/lib/graph.js
@@ -191,6 +191,9 @@ module.exports = function Graph(idOrElement, options, message) {
       // An array containing two-element arrays consisting of X and Y values for samples/points
       points = [],
 
+      // Consumers of points that have been added by user clicks
+      pointListeners = [],
+
       // An array containing 1 or more points arrays to be plotted. Data is not indexed here
       // and sorted when "sortPoints" option is enabled.
       pointArray,
@@ -1457,6 +1460,9 @@ module.exports = function Graph(idOrElement, options, message) {
           newpoint[0] = xScale.invert(Math.max(0, Math.min(size.width,  p[0])));
           newpoint[1] = yScale.invert(Math.max(0, Math.min(size.height, p[1])));
           points.push(newpoint);
+          pointListeners.forEach(function(callback) {
+            callback.call(null,newpoint);
+          });
           points.sort(function(a, b) {
             if (a[0] < b[0]) { return -1; }
             if (a[0] > b[0]) { return  1; }
@@ -2502,6 +2508,17 @@ module.exports = function Graph(idOrElement, options, message) {
     */
     brushListener: function() {
       return brushListener;
+    },
+
+    /**
+      Allow consumption of points added to graph through clicking
+      */
+    addPointListener: function(callback) {
+      pointListeners.push(callback);
+    },
+
+    clearPointListeners: function() {
+      pointListeners.length = 0;
     },
 
     // specific update functions ???


### PR DESCRIPTION
Add support for consumers of points added by clicking on the graph. For example, this would let the graph controller in Lab add user clicked points into a data set. For some of the RITES interactives we would like to have graphs that users draw graphs with a linked table showing the data points. This patch adds the necessary features to the grapher. 

Note that the pointListeners in here are only dispatching points added by clicking.
