### PR TITLE
Add dataColors option

### DIFF
--- a/dist/lab-grapher.js
+++ b/dist/lab-grapher.js
@@ -421,7 +421,17 @@ module.exports = function Graph(idOrElement, options, message) {
         lines:           true,
 
         // Render vertical bars extending up to samples/points
-        bars:            false
+        bars:            false,
+
+        // The R, G, and B values to be used to plot samples in each data channel. This default can
+        // be overridden at construction time, but the caller must provide colors for each channel.
+        // If there are n channels and m < n provided colors, the last n - m channels will be drawn
+        // using the last color in the list
+        dataColors: [
+          [160,   0,   0],         // channel 0   (red)
+          [ 44, 160,   0],         // channel 1   (green-yellow)
+          [ 44,   0, 160]          // channels 2+ (blue-purple)
+        ]
       },
 
       // brush selection variables
@@ -636,6 +646,11 @@ module.exports = function Graph(idOrElement, options, message) {
       options = default_options;
     }
     if (options.axisShift < 1) options.axisShift = 1;
+
+    // Clone dataColors array so that it's effectively immutable
+    for (var i = 0, len = options.dataColors.length; i < len; i++) {
+      options.dataColors[i] = options.dataColors[i].slice();
+    }
     return options;
   }
 
@@ -1307,7 +1322,7 @@ module.exports = function Graph(idOrElement, options, message) {
     gy.exit().remove();
 
     // For now, only annotations are of annotation.type === 'line' are supported
-    // so only generate attribute hash for lines and assume that we can directly 
+    // so only generate attribute hash for lines and assume that we can directly
     // append svg nodes of annotation.type
 
     function annotationAttributes(d) {
@@ -2148,39 +2163,16 @@ module.exports = function Graph(idOrElement, options, message) {
   }
 
   function setStrokeColor(i, afterSamplePoint) {
-    var opacity = afterSamplePoint ? 0.5 : 1.0;
-    switch(i) {
-      case 0:
-        gctx.strokeStyle = "rgba(160,00,0," + opacity + ")";
-        break;
-      case 1:
-        gctx.strokeStyle = "rgba(44,160,0," + opacity + ")";
-        break;
-      case 2:
-        gctx.strokeStyle = "rgba(44,0,160," + opacity + ")";
-        break;
-      default:
-        gctx.strokeStyle = "rgba(44,0,160," + opacity + ")";
-        break;
-    }
+    gctx.strokeStyle = getDataColor(i, afterSamplePoint ? 0.5 : 1.0);
   }
 
   function setFillColor(i, afterSamplePoint) {
-    var opacity = afterSamplePoint ? 0.4 : 1.0;
-    switch(i) {
-      case 0:
-        gctx.fillStyle = "rgba(160,00,0," + opacity + ")";
-        break;
-      case 1:
-        gctx.fillStyle = "rgba(44,160,0," + opacity + ")";
-        break;
-      case 2:
-        gctx.fillStyle = "rgba(44,0,160," + opacity + ")";
-        break;
-      default:
-        gctx.fillStyle = "rgba(44,0,160," + opacity + ")";
-        break;
-    }
+    gctx.fillStyle   = getDataColor(i, afterSamplePoint ? 0.4 : 1.0);
+  }
+
+  function getDataColor(i, opacity) {
+    var colorIndex = Math.min(i, options.dataColors.length);
+    return 'rgba(' +  options.dataColors[colorIndex].slice().concat(opacity).join(',') + ')';
   }
 
   // ------------------------------------------------------------

--- a/lib/graph.js
+++ b/lib/graph.js
@@ -340,7 +340,17 @@ module.exports = function Graph(idOrElement, options, message) {
         lines:           true,
 
         // Render vertical bars extending up to samples/points
-        bars:            false
+        bars:            false,
+
+        // The R, G, and B values to be used to plot samples in each data channel. This default can
+        // be overridden at construction time, but the caller must provide colors for each channel.
+        // If there are n channels and m < n provided colors, the last n - m channels will be drawn
+        // using the last color in the list
+        dataColors: [
+          [160,   0,   0],         // channel 0   (red)
+          [ 44, 160,   0],         // channel 1   (green-yellow)
+          [ 44,   0, 160]          // channels 2+ (blue-purple)
+        ]
       },
 
       // brush selection variables
@@ -555,6 +565,11 @@ module.exports = function Graph(idOrElement, options, message) {
       options = default_options;
     }
     if (options.axisShift < 1) options.axisShift = 1;
+
+    // Clone dataColors array so that it's effectively immutable
+    for (var i = 0, len = options.dataColors.length; i < len; i++) {
+      options.dataColors[i] = options.dataColors[i].slice();
+    }
     return options;
   }
 
@@ -1226,7 +1241,7 @@ module.exports = function Graph(idOrElement, options, message) {
     gy.exit().remove();
 
     // For now, only annotations are of annotation.type === 'line' are supported
-    // so only generate attribute hash for lines and assume that we can directly 
+    // so only generate attribute hash for lines and assume that we can directly
     // append svg nodes of annotation.type
 
     function annotationAttributes(d) {
@@ -2067,39 +2082,16 @@ module.exports = function Graph(idOrElement, options, message) {
   }
 
   function setStrokeColor(i, afterSamplePoint) {
-    var opacity = afterSamplePoint ? 0.5 : 1.0;
-    switch(i) {
-      case 0:
-        gctx.strokeStyle = "rgba(160,00,0," + opacity + ")";
-        break;
-      case 1:
-        gctx.strokeStyle = "rgba(44,160,0," + opacity + ")";
-        break;
-      case 2:
-        gctx.strokeStyle = "rgba(44,0,160," + opacity + ")";
-        break;
-      default:
-        gctx.strokeStyle = "rgba(44,0,160," + opacity + ")";
-        break;
-    }
+    gctx.strokeStyle = getDataColor(i, afterSamplePoint ? 0.5 : 1.0);
   }
 
   function setFillColor(i, afterSamplePoint) {
-    var opacity = afterSamplePoint ? 0.4 : 1.0;
-    switch(i) {
-      case 0:
-        gctx.fillStyle = "rgba(160,00,0," + opacity + ")";
-        break;
-      case 1:
-        gctx.fillStyle = "rgba(44,160,0," + opacity + ")";
-        break;
-      case 2:
-        gctx.fillStyle = "rgba(44,0,160," + opacity + ")";
-        break;
-      default:
-        gctx.fillStyle = "rgba(44,0,160," + opacity + ")";
-        break;
-    }
+    gctx.fillStyle   = getDataColor(i, afterSamplePoint ? 0.4 : 1.0);
+  }
+
+  function getDataColor(i, opacity) {
+    var colorIndex = Math.min(i, options.dataColors.length);
+    return 'rgba(' +  options.dataColors[colorIndex].slice().concat(opacity).join(',') + ')';
   }
 
   // ------------------------------------------------------------


### PR DESCRIPTION
Hi, 

For our AgentScript models we need to be able to set custom colors for each data "channel". This commit just creates an initialization-time option called dataColors which specifies the R, G, and B values to use for each channel. If no dataColors are provided, the default set (same as before) are used. Also same as before, the last channel color is re-used if there are more channels than colors.
