### PR TITLE
Grapher now accepts CSS colors instead of arrays

### DIFF
--- a/dist/lab-grapher.js
+++ b/dist/lab-grapher.js
@@ -440,9 +440,9 @@ module.exports = function Graph(idOrElement, options, message) {
         // If there are n channels and m < n provided colors, the last n - m channels will be drawn
         // using the last color in the list
         dataColors: [
-          [160,   0,   0],         // channel 0   (red)
-          [ 44, 160,   0],         // channel 1   (green-yellow)
-          [ 44,   0, 160]          // channels 2+ (blue-purple)
+          "#a00000",     // channel 0   (red)
+          "#2ca000",     // channel 1   (green-yellow)
+          "#2c00a0"      // channels 2+ (blue-purple)
         ],
 
         // An array of strings to be paired with the data colors to build a legend
@@ -975,7 +975,7 @@ module.exports = function Graph(idOrElement, options, message) {
       });
   }
   function createLegendLayer() {
-    var color = [0, 0, 0], item;
+    var color = "black", item;
     legendLayer = elem.append("ul");
 
     legendLayer
@@ -989,7 +989,7 @@ module.exports = function Graph(idOrElement, options, message) {
       item = legendLayer.append("li");
       item.append("div")
         .attr("class", "legend-colorsquare")
-        .style("background-color", "rgb(" + color.join(", ") + ")");
+        .style("background-color", color);
       item.append("label")
         .text(options.legendLabels[i]);
     }
@@ -2197,6 +2197,7 @@ module.exports = function Graph(idOrElement, options, message) {
       gctx.fillStyle = canvasFillStyle;
       gctx.fillRect(0, 0, gcanvas.width, gcanvas.height);
       gctx.strokeStyle = "rgba(255,65,0, 1.0)";
+      gctx.globalAlpha = 1;
     }
   }
 
@@ -2208,6 +2209,7 @@ module.exports = function Graph(idOrElement, options, message) {
       gctx.fillStyle = canvasFillStyle;
       gctx.fillRect(0, 0, gcanvas.width, gcanvas.height);
       gctx.strokeStyle = "rgba(255,65,0, 1.0)";
+      gctx.globalAlpha = 1;
     }
   }
 
@@ -2361,16 +2363,18 @@ module.exports = function Graph(idOrElement, options, message) {
   }
 
   function setStrokeColor(i, afterSamplePoint) {
-    gctx.strokeStyle = getDataColor(i, afterSamplePoint ? 0.5 : 1.0);
+    gctx.strokeStyle = getDataColor(i);
+    gctx.globalAlpha = afterSamplePoint ? 0.5 : 1.0;
   }
 
   function setFillColor(i, afterSamplePoint) {
-    gctx.fillStyle   = getDataColor(i, afterSamplePoint ? 0.4 : 1.0);
+    gctx.fillStyle   = getDataColor(i);
+    gctx.globalAlpha = afterSamplePoint ? 0.4 : 1.0;
   }
 
-  function getDataColor(i, opacity) {
+  function getDataColor(i) {
     var colorIndex = Math.min(i, options.dataColors.length - 1);
-    return 'rgba(' +  options.dataColors[colorIndex].slice().concat(opacity).join(',') + ')';
+    return colorIndex < 0 ? "black" : options.dataColors[colorIndex];
   }
 
   // ------------------------------------------------------------

--- a/lib/graph.js
+++ b/lib/graph.js
@@ -359,9 +359,9 @@ module.exports = function Graph(idOrElement, options, message) {
         // If there are n channels and m < n provided colors, the last n - m channels will be drawn
         // using the last color in the list
         dataColors: [
-          [160,   0,   0],         // channel 0   (red)
-          [ 44, 160,   0],         // channel 1   (green-yellow)
-          [ 44,   0, 160]          // channels 2+ (blue-purple)
+          "#a00000",     // channel 0   (red)
+          "#2ca000",     // channel 1   (green-yellow)
+          "#2c00a0"      // channels 2+ (blue-purple)
         ],
 
         // An array of strings to be paired with the data colors to build a legend
@@ -894,7 +894,7 @@ module.exports = function Graph(idOrElement, options, message) {
       });
   }
   function createLegendLayer() {
-    var color = [0, 0, 0], item;
+    var color = "black", item;
     legendLayer = elem.append("ul");
 
     legendLayer
@@ -908,7 +908,7 @@ module.exports = function Graph(idOrElement, options, message) {
       item = legendLayer.append("li");
       item.append("div")
         .attr("class", "legend-colorsquare")
-        .style("background-color", "rgb(" + color.join(", ") + ")");
+        .style("background-color", color);
       item.append("label")
         .text(options.legendLabels[i]);
     }
@@ -2116,6 +2116,7 @@ module.exports = function Graph(idOrElement, options, message) {
       gctx.fillStyle = canvasFillStyle;
       gctx.fillRect(0, 0, gcanvas.width, gcanvas.height);
       gctx.strokeStyle = "rgba(255,65,0, 1.0)";
+      gctx.globalAlpha = 1;
     }
   }
 
@@ -2127,6 +2128,7 @@ module.exports = function Graph(idOrElement, options, message) {
       gctx.fillStyle = canvasFillStyle;
       gctx.fillRect(0, 0, gcanvas.width, gcanvas.height);
       gctx.strokeStyle = "rgba(255,65,0, 1.0)";
+      gctx.globalAlpha = 1;
     }
   }
 
@@ -2280,16 +2282,18 @@ module.exports = function Graph(idOrElement, options, message) {
   }
 
   function setStrokeColor(i, afterSamplePoint) {
-    gctx.strokeStyle = getDataColor(i, afterSamplePoint ? 0.5 : 1.0);
+    gctx.strokeStyle = getDataColor(i);
+    gctx.globalAlpha = afterSamplePoint ? 0.5 : 1.0;
   }
 
   function setFillColor(i, afterSamplePoint) {
-    gctx.fillStyle   = getDataColor(i, afterSamplePoint ? 0.4 : 1.0);
+    gctx.fillStyle   = getDataColor(i);
+    gctx.globalAlpha = afterSamplePoint ? 0.4 : 1.0;
   }
 
-  function getDataColor(i, opacity) {
+  function getDataColor(i) {
     var colorIndex = Math.min(i, options.dataColors.length - 1);
-    return 'rgba(' +  options.dataColors[colorIndex].slice().concat(opacity).join(',') + ')';
+    return colorIndex < 0 ? "black" : options.dataColors[colorIndex];
   }
 
   // ------------------------------------------------------------


### PR DESCRIPTION
Works in the graph itself as well as in the legend.
[#74535922]
[#74536668]
