### PR TITLE
Add "buttonsStyle" and "buttonsLayout" options

### DIFF
--- a/css/lab-grapher.css
+++ b/css/lab-grapher.css
@@ -12,23 +12,38 @@
 .graph .title-background {
     fill: transparent;
 }
-.graph div.button-layer {
+
+.graph .button-layer {
     position: absolute;
     text-align: right;
 }
-.graph div.button-layer a {
+.graph .button-layer a {
     opacity: 0.3;
     color: black;
-    font-size: 120%;
+    font-size: 0.9em;
+    cursor: pointer;
+    display: block;
+    margin-bottom: 0.2em;
 }
-.graph div.button-layer a:hover {
+.graph .button-layer.horizontal a {
+    display: inline-block;
+    margin-bottom: 0;
+    margin-right: 1.3em;
+    opacity: 0.6;
+    font-size: 0.8em;
+}
+.graph .button-layer a i {
+    font-size: 1.33em;
+}
+.graph .button-layer a:hover {
     opacity: 1;
 }
-.graph div.button-layer a:active {
+.graph .button-layer a:active {
     opacity: 0.6;
 }
-.graph div.button-layer .active {
-  color: #00b4d6;
+.graph .button-layer .active {
+    color: #00b4d6;
+    opacity: 0.6;
 }
 
 .graph ul.legend-layer {

--- a/dist/lab-grapher.js
+++ b/dist/lab-grapher.js
@@ -250,6 +250,9 @@ module.exports = function Graph(idOrElement, options, message) {
         large: 1920
       },
 
+      // Padding of a title when it's placed on the left side.
+      titleLeftPadding = "10px",
+
       // State variables indicating whether an axis drag operation is in place.
       // NaN values are used to indicate operation not in progress and
       // checked like this: if (!isNaN(downx)) { resacle operation in progress }
@@ -310,13 +313,17 @@ module.exports = function Graph(idOrElement, options, message) {
 
       // The default options for a graph
       default_options = {
-        // Enables the button layer with: AutoScale ...
-        showButtons:    true,
+        // Enables the button layer with: AutoScale...
+        showButtons: true,
+        // "icons" or "text".
+        buttonsStyle: "icons",
+        // "vertical" (overlaps with the plotting area) or "horizontal" (right below the title).
+        buttonsLayout: "vertical",
 
         // Whether or not to show the graph's legend
         legendVisible: false,
 
-        // Responsive Layout provides pregressive removal of
+        // Responsive Layout provides progressive removal of
         // graph elements when size gets smaller
         responsiveLayout: false,
 
@@ -324,7 +331,7 @@ module.exports = function Graph(idOrElement, options, message) {
         // When fontScaleRelativeToParent to true the font-size of the
         // containing element is set based on the size of the containing
         // element. hs means whn the containing element is smaller the
-        // foint-size of the labels in thegraph will be smaller.
+        // font-size of the labels in the graph will be smaller.
         fontScaleRelativeToParent: true,
         hideAxisValues: false,
 
@@ -681,6 +688,18 @@ module.exports = function Graph(idOrElement, options, message) {
     return options;
   }
 
+  function getTopPadding() {
+    var topPadding = fontSizeInPixels;
+    if (options.title) {
+      topPadding = titleFontSizeInPixels * 1.8;
+    }
+    if (options.buttonsLayout === "horizontal") {
+      // Leave some space for buttons.
+      topPadding += fontSizeInPixels * 1.3;
+    }
+    return topPadding;
+  }
+
   function updateAxesAndSize() {
     xlabelMetrics = [fontSizeInPixels, fontSizeInPixels];
     ylabelMetrics = [fontSizeInPixels*2, fontSizeInPixels];
@@ -731,7 +750,7 @@ module.exports = function Graph(idOrElement, options, message) {
 
       case 1:         // tiny
       padding = {
-        "top":    options.title  ? titleFontSizeInPixels*1.8 : fontSizeInPixels,
+        "top":    getTopPadding(),
         "right":  halfFontSizeInPixels,
         "bottom": xlabelFontSizeInPixels*1.25,
         "left":   ylabelFontSizeInPixels*1.25
@@ -740,7 +759,7 @@ module.exports = function Graph(idOrElement, options, message) {
 
       case 2:         // small
       padding = {
-        "top":    options.title  ? titleFontSizeInPixels*1.8 : fontSizeInPixels,
+        "top":    getTopPadding(),
         "right":  xAxisLabelHorizontalPadding,
         "bottom": options.hideAxisValues ? xlabelFontSizeInPixels*1.25 : axisFontSizeInPixels*1.25,
         "left": options.hideAxisValues ? ylabelFontSizeInPixels*1.25 : yAxisNumberWidth*1.25
@@ -751,7 +770,7 @@ module.exports = function Graph(idOrElement, options, message) {
 
       case 3:         // medium
       padding = {
-        "top":    options.title  ? titleFontSizeInPixels*1.8 : fontSizeInPixels,
+        "top":    getTopPadding(),
         "right":  xAxisLabelHorizontalPadding,
         "bottom": options.hideAxisValues ? xlabelFontSizeInPixels*1.25 : (options.xlabel ? xAxisVerticalPadding : axisFontSizeInPixels*1.25),
         "left": options.hideAxisValues ? ylabelFontSizeInPixels*1.25 : (options.ylabel ? yAxisHorizontalPadding : yAxisNumberWidth)
@@ -760,7 +779,7 @@ module.exports = function Graph(idOrElement, options, message) {
 
       default:         // large
       padding = {
-        "top":    options.title  ? titleFontSizeInPixels*1.8 : fontSizeInPixels,
+        "top":    getTopPadding(),
         "right":  xAxisLabelHorizontalPadding,
         "bottom": options.hideAxisValues ? xlabelFontSizeInPixels*1.25 : (options.xlabel ? xAxisVerticalPadding : axisFontSizeInPixels*1.25),
         "left": options.hideAxisValues ? ylabelFontSizeInPixels*1.25 : (options.ylabel ? yAxisHorizontalPadding : yAxisNumberWidth)
@@ -924,67 +943,85 @@ module.exports = function Graph(idOrElement, options, message) {
     if (options.enableLegendButton && options.legendLabels.length > 0) {
       legendButton = buttonLayer.append('a');
       legendButton.attr({
-            "class": "legend-button",
+            "class": "graph-button",
             "title": i18n.t("tooltips.legend")
           })
           .on("click", function() {
             toggleLegend();
-          })
-          .append("i")
-            .attr("class", "icon-list-ul");
+          });
+      if (options.buttonsStyle === "icons") {
+        legendButton.append("i").attr("class", "icon-list-ul");
+      } else {
+        legendButton.text("Key");
+      }
     }
 
     if (options.enableAutoScaleButton) {
-      buttonLayer.append('a')
-          .attr({
-            "class": "autoscale-button",
+      var autoscaleButton = buttonLayer.append('a');
+      autoscaleButton.attr({
+            "class": "graph-button",
             "title": i18n.t("tooltips.autoscale")
           })
           .on("click", function() {
             autoscale(true);
             redraw();
-          })
-          .append("i")
-            .attr("class", "icon-picture");
+          });
+      if (options.buttonsStyle === "icons") {
+        autoscaleButton.append("i").attr("class", "icon-picture");
+      } else {
+        autoscaleButton.text("Zoom");
+      }
     }
 
     if (options.enableSelectionButton) {
       selectionButton = buttonLayer.append('a');
       selectionButton.attr({
-            "class": "selection-button",
+            "class": "graph-button",
             "title": i18n.t("tooltips.selection")
           })
           .on("click", function() {
             toggleSelection();
-          })
-          .append("i")
-            .attr("class", "icon-cut");
+          });
+      if (options.buttonsStyle === "icons") {
+        selectionButton.append("i").attr("class", "icon-cut");
+      } else {
+        selectionButton.text("Select");
+      }
     }
 
     if (options.enableDrawButton) {
       drawButton = buttonLayer.append('a');
       drawButton.attr({
-            "class": "draw-button",
+            "class": "graph-button",
             "title": i18n.t("tooltips.draw")
           })
           .on("click", function() {
             toggleDraw();
-          })
-          .append("i")
-            .attr("class", "icon-pencil");
+          });
+      if (options.buttonsStyle === "icons") {
+        drawButton.append("i").attr("class", "icon-pencil");
+      } else {
+        drawButton.text("Draw");
+      }
     }
 
     resizeButtonLayer();
   }
 
   function resizeButtonLayer() {
-    buttonLayer
-      .style({
-        "width":   fontSizeInPixels*1.75 + "px",
-        "height":  fontSizeInPixels*1.25 + "px",
-        "top":     padding.top + halfFontSizeInPixels + "px",
-        "left":    padding.left + (size.width - fontSizeInPixels*2.0) + "px"
+    if (options.buttonsLayout === "vertical") {
+      buttonLayer.style({
+        "top":   padding.top + halfFontSizeInPixels * 0.5 + "px",
+        "right": padding.right + halfFontSizeInPixels * 0.5 + "px"
       });
+      buttonLayer.classed("horizontal", false);
+    } else if (options.buttonsLayout === "horizontal") {
+      buttonLayer.style({
+        "top":  padding.top - fontSizeInPixels * 1.9 + "px",
+        "left": titleLeftPadding
+      });
+      buttonLayer.classed("horizontal", true);
+    }
   }
   function createLegendLayer() {
     var color = "black", item;
@@ -1178,7 +1215,7 @@ module.exports = function Graph(idOrElement, options, message) {
         .attr("class", "title")
         .text(function(d) { return d; })
         .attr("x", options.titlePosition === "center" ?
-          function() { return padding.left + size.width/2 - Math.min(size.width, getComputedTextLength(this))/2; } : 10) // 10 - small margin
+          function() { return padding.left + size.width/2 - Math.min(size.width, getComputedTextLength(this))/2; } : titleLeftPadding)
         .attr("y", titleFontSizeInPixels * 1.1)
         .attr("dy", function(d, i) { return -i * titleFontSizeInPixels + "px"; });
       titleTooltip = title.append("title")
@@ -1254,11 +1291,11 @@ module.exports = function Graph(idOrElement, options, message) {
         .attr("y", 0)
         .attr("width", size.width + padding.left)
         // Leave some space for the last tick mark number.
-        .attr("height", padding.top - halfFontSizeInPixels * 0.8);
+        .attr("height", titleFontSizeInPixels * 1.8 - halfFontSizeInPixels * 0.8);
 
       title
           .attr("x", options.titlePosition === "center" ?
-                     function() { return padding.left + size.width/2 - Math.min(size.width, getComputedTextLength(this))/2; } : 10) // 10 - small margin
+                     function() { return padding.left + size.width/2 - Math.min(size.width, getComputedTextLength(this))/2; } : titleLeftPadding)
           .attr("y", titleFontSizeInPixels * 1.1)
           .attr("dy", function(d, i) { return -i * titleFontSizeInPixels + "px"; });
       titleTooltip
@@ -2251,7 +2288,8 @@ module.exports = function Graph(idOrElement, options, message) {
         legendLayer
           .style({
             "top":     padding.top + halfFontSizeInPixels + "px",
-            "right":   padding.right + (options.showButtons ? fontSizeInPixels*2.0 : halfFontSizeInPixels) + "px"
+            "right":   padding.right + halfFontSizeInPixels +
+                       (options.showButtons && options.buttonsLayout === "vertical" ? buttonLayer.property('clientWidth') : 0) + "px"
           });
       } else {
         legendLayer.classed("legend-invisible", true);
@@ -2838,7 +2876,6 @@ module.exports = function Graph(idOrElement, options, message) {
     }
     if (options.showButtons) {
       if (!buttonLayer) createButtonLayer();
-      resizeButtonLayer();
     }
     if (options.legendLabels.length > 0) {
       if (!legendLayer) {

--- a/examples/examples.js
+++ b/examples/examples.js
@@ -145,7 +145,8 @@ function selectDataHandler() {
         ymin:   13,
         xFormatter: ".3r",
         yFormatter: ".1f",
-
+        legendLabels: ["temperature"],
+        enableSelectionButton: true,
 
         onXDomainChange: function (min, max) {
           console.log('X domain changed: [' + min + ', ' + max + ']');
@@ -522,6 +523,9 @@ function getOptions(otherOptions) {
   $("input.graph-option").each(function () {
     result[this.name] = this.checked;
   });
+  $("select.graph-option").each(function () {
+    result[this.name] = $(this).val();
+  });
   $.extend(result, otherOptions);
   return result;
 }
@@ -582,6 +586,6 @@ $(window).bind('hashchange', function () {
   }
 });
 
-$("input.graph-option").each(function () {
+$(".graph-option").each(function () {
   $(this).on('change', selectDataHandler);
 });

--- a/examples/index.html
+++ b/examples/index.html
@@ -67,6 +67,28 @@
             <li><label><input type='checkbox' class="graph-option" name="hideAxisValues">hideAxisValues</label></li>
             <li><label><input type='checkbox' class="graph-option" name="enableAxisScaling" checked>enableAxisScaling</label></li>
             <li><label><input type='checkbox' class="graph-option" name="enableZooming" checked>enableZooming</label></li>
+            <li><label><input type='checkbox' class="graph-option" name="useIcons" checked>useIcons</label></li>
+            <li><label>
+              buttonsLayout
+              <select class="graph-option" name="buttonsLayout">
+                <option value="vertical">vertical</option>
+                <option value="horizontal">horizontal</option>
+              </select>
+            </label></li>
+            <li><label>
+              buttonsStyle
+              <select class="graph-option" name="buttonsStyle">
+                <option value="icons">icons</option>
+                <option value="text">text</option>
+              </select>
+            </label></li>
+            <li><label>
+              titlePosition
+              <select class="graph-option" name="titlePosition">
+                <option value="center">center</option>
+                <option value="left">left</option>
+              </select>
+            </label></li>
           </ul>
         </p>
       </div>

--- a/examples/index.html
+++ b/examples/index.html
@@ -67,7 +67,6 @@
             <li><label><input type='checkbox' class="graph-option" name="hideAxisValues">hideAxisValues</label></li>
             <li><label><input type='checkbox' class="graph-option" name="enableAxisScaling" checked>enableAxisScaling</label></li>
             <li><label><input type='checkbox' class="graph-option" name="enableZooming" checked>enableZooming</label></li>
-            <li><label><input type='checkbox' class="graph-option" name="useIcons" checked>useIcons</label></li>
             <li><label>
               buttonsLayout
               <select class="graph-option" name="buttonsLayout">

--- a/lib/graph.js
+++ b/lib/graph.js
@@ -169,6 +169,9 @@ module.exports = function Graph(idOrElement, options, message) {
         large: 1920
       },
 
+      // Padding of a title when it's placed on the left side.
+      titleLeftPadding = "10px",
+
       // State variables indicating whether an axis drag operation is in place.
       // NaN values are used to indicate operation not in progress and
       // checked like this: if (!isNaN(downx)) { resacle operation in progress }
@@ -229,13 +232,17 @@ module.exports = function Graph(idOrElement, options, message) {
 
       // The default options for a graph
       default_options = {
-        // Enables the button layer with: AutoScale ...
-        showButtons:    true,
+        // Enables the button layer with: AutoScale...
+        showButtons: true,
+        // "icons" or "text".
+        buttonsStyle: "icons",
+        // "vertical" (overlaps with the plotting area) or "horizontal" (right below the title).
+        buttonsLayout: "vertical",
 
         // Whether or not to show the graph's legend
         legendVisible: false,
 
-        // Responsive Layout provides pregressive removal of
+        // Responsive Layout provides progressive removal of
         // graph elements when size gets smaller
         responsiveLayout: false,
 
@@ -243,7 +250,7 @@ module.exports = function Graph(idOrElement, options, message) {
         // When fontScaleRelativeToParent to true the font-size of the
         // containing element is set based on the size of the containing
         // element. hs means whn the containing element is smaller the
-        // foint-size of the labels in thegraph will be smaller.
+        // font-size of the labels in the graph will be smaller.
         fontScaleRelativeToParent: true,
         hideAxisValues: false,
 
@@ -600,6 +607,18 @@ module.exports = function Graph(idOrElement, options, message) {
     return options;
   }
 
+  function getTopPadding() {
+    var topPadding = fontSizeInPixels;
+    if (options.title) {
+      topPadding = titleFontSizeInPixels * 1.8;
+    }
+    if (options.buttonsLayout === "horizontal") {
+      // Leave some space for buttons.
+      topPadding += fontSizeInPixels * 1.3;
+    }
+    return topPadding;
+  }
+
   function updateAxesAndSize() {
     xlabelMetrics = [fontSizeInPixels, fontSizeInPixels];
     ylabelMetrics = [fontSizeInPixels*2, fontSizeInPixels];
@@ -650,7 +669,7 @@ module.exports = function Graph(idOrElement, options, message) {
 
       case 1:         // tiny
       padding = {
-        "top":    options.title  ? titleFontSizeInPixels*1.8 : fontSizeInPixels,
+        "top":    getTopPadding(),
         "right":  halfFontSizeInPixels,
         "bottom": xlabelFontSizeInPixels*1.25,
         "left":   ylabelFontSizeInPixels*1.25
@@ -659,7 +678,7 @@ module.exports = function Graph(idOrElement, options, message) {
 
       case 2:         // small
       padding = {
-        "top":    options.title  ? titleFontSizeInPixels*1.8 : fontSizeInPixels,
+        "top":    getTopPadding(),
         "right":  xAxisLabelHorizontalPadding,
         "bottom": options.hideAxisValues ? xlabelFontSizeInPixels*1.25 : axisFontSizeInPixels*1.25,
         "left": options.hideAxisValues ? ylabelFontSizeInPixels*1.25 : yAxisNumberWidth*1.25
@@ -670,7 +689,7 @@ module.exports = function Graph(idOrElement, options, message) {
 
       case 3:         // medium
       padding = {
-        "top":    options.title  ? titleFontSizeInPixels*1.8 : fontSizeInPixels,
+        "top":    getTopPadding(),
         "right":  xAxisLabelHorizontalPadding,
         "bottom": options.hideAxisValues ? xlabelFontSizeInPixels*1.25 : (options.xlabel ? xAxisVerticalPadding : axisFontSizeInPixels*1.25),
         "left": options.hideAxisValues ? ylabelFontSizeInPixels*1.25 : (options.ylabel ? yAxisHorizontalPadding : yAxisNumberWidth)
@@ -679,7 +698,7 @@ module.exports = function Graph(idOrElement, options, message) {
 
       default:         // large
       padding = {
-        "top":    options.title  ? titleFontSizeInPixels*1.8 : fontSizeInPixels,
+        "top":    getTopPadding(),
         "right":  xAxisLabelHorizontalPadding,
         "bottom": options.hideAxisValues ? xlabelFontSizeInPixels*1.25 : (options.xlabel ? xAxisVerticalPadding : axisFontSizeInPixels*1.25),
         "left": options.hideAxisValues ? ylabelFontSizeInPixels*1.25 : (options.ylabel ? yAxisHorizontalPadding : yAxisNumberWidth)
@@ -843,67 +862,85 @@ module.exports = function Graph(idOrElement, options, message) {
     if (options.enableLegendButton && options.legendLabels.length > 0) {
       legendButton = buttonLayer.append('a');
       legendButton.attr({
-            "class": "legend-button",
+            "class": "graph-button",
             "title": i18n.t("tooltips.legend")
           })
           .on("click", function() {
             toggleLegend();
-          })
-          .append("i")
-            .attr("class", "icon-list-ul");
+          });
+      if (options.buttonsStyle === "icons") {
+        legendButton.append("i").attr("class", "icon-list-ul");
+      } else {
+        legendButton.text("Key");
+      }
     }
 
     if (options.enableAutoScaleButton) {
-      buttonLayer.append('a')
-          .attr({
-            "class": "autoscale-button",
+      var autoscaleButton = buttonLayer.append('a');
+      autoscaleButton.attr({
+            "class": "graph-button",
             "title": i18n.t("tooltips.autoscale")
           })
           .on("click", function() {
             autoscale(true);
             redraw();
-          })
-          .append("i")
-            .attr("class", "icon-picture");
+          });
+      if (options.buttonsStyle === "icons") {
+        autoscaleButton.append("i").attr("class", "icon-picture");
+      } else {
+        autoscaleButton.text("Zoom");
+      }
     }
 
     if (options.enableSelectionButton) {
       selectionButton = buttonLayer.append('a');
       selectionButton.attr({
-            "class": "selection-button",
+            "class": "graph-button",
             "title": i18n.t("tooltips.selection")
           })
           .on("click", function() {
             toggleSelection();
-          })
-          .append("i")
-            .attr("class", "icon-cut");
+          });
+      if (options.buttonsStyle === "icons") {
+        selectionButton.append("i").attr("class", "icon-cut");
+      } else {
+        selectionButton.text("Select");
+      }
     }
 
     if (options.enableDrawButton) {
       drawButton = buttonLayer.append('a');
       drawButton.attr({
-            "class": "draw-button",
+            "class": "graph-button",
             "title": i18n.t("tooltips.draw")
           })
           .on("click", function() {
             toggleDraw();
-          })
-          .append("i")
-            .attr("class", "icon-pencil");
+          });
+      if (options.buttonsStyle === "icons") {
+        drawButton.append("i").attr("class", "icon-pencil");
+      } else {
+        drawButton.text("Draw");
+      }
     }
 
     resizeButtonLayer();
   }
 
   function resizeButtonLayer() {
-    buttonLayer
-      .style({
-        "width":   fontSizeInPixels*1.75 + "px",
-        "height":  fontSizeInPixels*1.25 + "px",
-        "top":     padding.top + halfFontSizeInPixels + "px",
-        "left":    padding.left + (size.width - fontSizeInPixels*2.0) + "px"
+    if (options.buttonsLayout === "vertical") {
+      buttonLayer.style({
+        "top":   padding.top + halfFontSizeInPixels * 0.5 + "px",
+        "right": padding.right + halfFontSizeInPixels * 0.5 + "px"
       });
+      buttonLayer.classed("horizontal", false);
+    } else if (options.buttonsLayout === "horizontal") {
+      buttonLayer.style({
+        "top":  padding.top - fontSizeInPixels * 1.9 + "px",
+        "left": titleLeftPadding
+      });
+      buttonLayer.classed("horizontal", true);
+    }
   }
   function createLegendLayer() {
     var color = "black", item;
@@ -1097,7 +1134,7 @@ module.exports = function Graph(idOrElement, options, message) {
         .attr("class", "title")
         .text(function(d) { return d; })
         .attr("x", options.titlePosition === "center" ?
-          function() { return padding.left + size.width/2 - Math.min(size.width, getComputedTextLength(this))/2; } : 10) // 10 - small margin
+          function() { return padding.left + size.width/2 - Math.min(size.width, getComputedTextLength(this))/2; } : titleLeftPadding)
         .attr("y", titleFontSizeInPixels * 1.1)
         .attr("dy", function(d, i) { return -i * titleFontSizeInPixels + "px"; });
       titleTooltip = title.append("title")
@@ -1173,11 +1210,11 @@ module.exports = function Graph(idOrElement, options, message) {
         .attr("y", 0)
         .attr("width", size.width + padding.left)
         // Leave some space for the last tick mark number.
-        .attr("height", padding.top - halfFontSizeInPixels * 0.8);
+        .attr("height", titleFontSizeInPixels * 1.8 - halfFontSizeInPixels * 0.8);
 
       title
           .attr("x", options.titlePosition === "center" ?
-                     function() { return padding.left + size.width/2 - Math.min(size.width, getComputedTextLength(this))/2; } : 10) // 10 - small margin
+                     function() { return padding.left + size.width/2 - Math.min(size.width, getComputedTextLength(this))/2; } : titleLeftPadding)
           .attr("y", titleFontSizeInPixels * 1.1)
           .attr("dy", function(d, i) { return -i * titleFontSizeInPixels + "px"; });
       titleTooltip
@@ -2170,7 +2207,8 @@ module.exports = function Graph(idOrElement, options, message) {
         legendLayer
           .style({
             "top":     padding.top + halfFontSizeInPixels + "px",
-            "right":   padding.right + (options.showButtons ? fontSizeInPixels*2.0 : halfFontSizeInPixels) + "px"
+            "right":   padding.right + halfFontSizeInPixels +
+                       (options.showButtons && options.buttonsLayout === "vertical" ? buttonLayer.property('clientWidth') : 0) + "px"
           });
       } else {
         legendLayer.classed("legend-invisible", true);
@@ -2757,7 +2795,6 @@ module.exports = function Graph(idOrElement, options, message) {
     }
     if (options.showButtons) {
       if (!buttonLayer) createButtonLayer();
-      resizeButtonLayer();
     }
     if (options.legendLabels.length > 0) {
       if (!legendLayer) {


### PR DESCRIPTION
You can switch between icons and text and also decide whether buttons should be on the right side or below the title. I've merged this branch into gh-pages, so you can play with new options here:
http://concord-consortium.github.io/lab-grapher/examples/#earth-surface-temperature

I know this code adds even more fiddling with magic values of paddings, font sizes etc., but that's general grapher's style and I don't think it makes sense to fight with it right now. I would really consider rewriting grapher at some point, I believe that motivated developer can do it in 2-4 weeks. :wink: