### PR TITLE
Make text buttons translatable, add 'lang' option

### DIFF
--- a/dist/lab-grapher.js
+++ b/dist/lab-grapher.js
@@ -313,6 +313,7 @@ module.exports = function Graph(idOrElement, options, message) {
 
       // The default options for a graph
       default_options = {
+        lang: "en-US",
         // Enables the button layer with: AutoScale...
         showButtons: true,
         // "icons" or "text".
@@ -496,6 +497,7 @@ module.exports = function Graph(idOrElement, options, message) {
     if (opts || !options) {
       options = setupOptions(opts);
     }
+    i18n.lang = options.lang;
 
     initializeLayout(idOrElement, mesg);
 
@@ -952,7 +954,7 @@ module.exports = function Graph(idOrElement, options, message) {
       if (options.buttonsStyle === "icons") {
         legendButton.append("i").attr("class", "icon-list-ul");
       } else {
-        legendButton.text("Key");
+        legendButton.text(i18n.t("labels.legend"));
       }
     }
 
@@ -969,7 +971,7 @@ module.exports = function Graph(idOrElement, options, message) {
       if (options.buttonsStyle === "icons") {
         autoscaleButton.append("i").attr("class", "icon-picture");
       } else {
-        autoscaleButton.text("Zoom");
+        autoscaleButton.text(i18n.t("labels.autoscale"));
       }
     }
 
@@ -985,7 +987,7 @@ module.exports = function Graph(idOrElement, options, message) {
       if (options.buttonsStyle === "icons") {
         selectionButton.append("i").attr("class", "icon-cut");
       } else {
-        selectionButton.text("Select");
+        selectionButton.text(i18n.t("labels.selection"));
       }
     }
 
@@ -1001,7 +1003,7 @@ module.exports = function Graph(idOrElement, options, message) {
       if (options.buttonsStyle === "icons") {
         drawButton.append("i").attr("class", "icon-pencil");
       } else {
-        drawButton.text("Draw");
+        drawButton.text(i18n.t("labels.draw"));
       }
     }
 
@@ -3166,6 +3168,12 @@ function getTranslation(lang, key) {
 },{"../locales/translations.json":4}],4:[function(require,module,exports){
 module.exports={
   "en-US": {
+    "labels": {
+      "autoscale": "Zoom",
+      "draw"     : "Draw",
+      "selection": "Select",
+      "legend"   : "Key"
+    },
     "tooltips": {
         "autoscale": "Show all data (autoscale)",
         "draw"     : "Draw new data points",
@@ -3174,9 +3182,17 @@ module.exports={
     }
   },
   "pl": {
+    "labels": {
+      "autoscale": "Przybliż",
+      "draw"     : "Rysuj",
+      "selection": "Zaznacz",
+      "legend"   : "Legenda"
+    },
     "tooltips": {
         "autoscale": "Pokaż cały wykres (autoskalowanie)",
-        "selection": "Zaznacz dane do wyeksportowania"
+        "draw"     : "Rysuj nowe punkty",
+        "selection": "Zaznacz dane do wyeksportowania",
+        "legend"   : "Pokaż/ukryj legendę"
     }
   }
 }

--- a/examples/examples.js
+++ b/examples/examples.js
@@ -86,7 +86,6 @@ function selectDataHandler() {
   case "fake-drawable":
     graph.reset('#chart', getOptions({
       title:  "Fake Data (drawable)",
-
       fontScaleRelativeToParent: false,
       dataType: 'fake',
 
@@ -511,6 +510,16 @@ function selectDataHandler() {
       value2 = Math.sin(twopifreq2 * time) * amplitude2;
       graph.addSamples([[(value1 + value2)], [0-(value1+value2)]]);
     }, 1000*sampleInterval);
+    break;
+
+  case "i18n-example":
+    graph.reset('#chart', getOptions({
+      lang: "pl",
+      enableSelectionButton: true,
+      enableDrawButton: true,
+      enableAutoScaleButton: true,
+      legendLabels: ["test1", "test2"]
+    }));
     break;
   }
 }

--- a/examples/index.html
+++ b/examples/index.html
@@ -36,6 +36,7 @@
           <option value='realtime-markers-drawable'>Realtime w/ Markers (drawable)</option>
           <option value='multiline-realtime-markers'>Realtime Multiple Lines w/ Markers</option>
           <option value='multiline-realtime-markers-drawable'>Realtime Multiple Lines w/ Markers (drawable)</option>
+          <option value='i18n-example'>i18n Example</option>
         </select>
       </p>
       <div id="graph-parent-container">

--- a/lib/graph.js
+++ b/lib/graph.js
@@ -232,6 +232,7 @@ module.exports = function Graph(idOrElement, options, message) {
 
       // The default options for a graph
       default_options = {
+        lang: "en-US",
         // Enables the button layer with: AutoScale...
         showButtons: true,
         // "icons" or "text".
@@ -415,6 +416,7 @@ module.exports = function Graph(idOrElement, options, message) {
     if (opts || !options) {
       options = setupOptions(opts);
     }
+    i18n.lang = options.lang;
 
     initializeLayout(idOrElement, mesg);
 
@@ -871,7 +873,7 @@ module.exports = function Graph(idOrElement, options, message) {
       if (options.buttonsStyle === "icons") {
         legendButton.append("i").attr("class", "icon-list-ul");
       } else {
-        legendButton.text("Key");
+        legendButton.text(i18n.t("labels.legend"));
       }
     }
 
@@ -888,7 +890,7 @@ module.exports = function Graph(idOrElement, options, message) {
       if (options.buttonsStyle === "icons") {
         autoscaleButton.append("i").attr("class", "icon-picture");
       } else {
-        autoscaleButton.text("Zoom");
+        autoscaleButton.text(i18n.t("labels.autoscale"));
       }
     }
 
@@ -904,7 +906,7 @@ module.exports = function Graph(idOrElement, options, message) {
       if (options.buttonsStyle === "icons") {
         selectionButton.append("i").attr("class", "icon-cut");
       } else {
-        selectionButton.text("Select");
+        selectionButton.text(i18n.t("labels.selection"));
       }
     }
 
@@ -920,7 +922,7 @@ module.exports = function Graph(idOrElement, options, message) {
       if (options.buttonsStyle === "icons") {
         drawButton.append("i").attr("class", "icon-pencil");
       } else {
-        drawButton.text("Draw");
+        drawButton.text(i18n.t("labels.draw"));
       }
     }
 

--- a/locales/translations.json
+++ b/locales/translations.json
@@ -1,5 +1,11 @@
 {
   "en-US": {
+    "labels": {
+      "autoscale": "Zoom",
+      "draw"     : "Draw",
+      "selection": "Select",
+      "legend"   : "Key"
+    },
     "tooltips": {
         "autoscale": "Show all data (autoscale)",
         "draw"     : "Draw new data points",
@@ -8,9 +14,17 @@
     }
   },
   "pl": {
+    "labels": {
+      "autoscale": "Przybliż",
+      "draw"     : "Rysuj",
+      "selection": "Zaznacz",
+      "legend"   : "Legenda"
+    },
     "tooltips": {
         "autoscale": "Pokaż cały wykres (autoskalowanie)",
-        "selection": "Zaznacz dane do wyeksportowania"
+        "draw"     : "Rysuj nowe punkty",
+        "selection": "Zaznacz dane do wyeksportowania",
+        "legend"   : "Pokaż/ukryj legendę"
     }
   }
 }


### PR DESCRIPTION
This PR makes text buttons translatable, adds i18n-example and a new "lang" option (so the example was possible to implement).

[#128761165]